### PR TITLE
fix the aot build by not using barrel import

### DIFF
--- a/projects/notification-widget/src/lib/notification-list/index.ts
+++ b/projects/notification-widget/src/lib/notification-list/index.ts
@@ -1,1 +1,0 @@
-export * from './notification-list.component';

--- a/projects/notification-widget/src/lib/notification-widget.module.ts
+++ b/projects/notification-widget/src/lib/notification-widget.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
-import { NotificationListComponent } from './notification-list';
-import { NotificationWidgetComponent } from './notification-widget';
+import { NotificationListComponent } from './notification-list/notification-list.component';
+import { NotificationWidgetComponent } from './notification-widget/notification-widget.component';
 import { NotificationWidgetService } from './notification-widget.service';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';

--- a/projects/notification-widget/src/lib/notification-widget/index.ts
+++ b/projects/notification-widget/src/lib/notification-widget/index.ts
@@ -1,1 +1,0 @@
-export * from './notification-widget.component';

--- a/projects/notification-widget/src/public-api.ts
+++ b/projects/notification-widget/src/public-api.ts
@@ -2,6 +2,6 @@
  * Public API Surface of notification-widget
  */
 export * from './lib/notification-widget.service';
-export * from './lib/notification-widget';
-export * from './lib/notification-list';
+export * from './lib/notification-widget/notification-widget.component';
+export * from './lib/notification-list/notification-list.component';
 export * from './lib/notification-widget.module';


### PR DESCRIPTION
When doing `ng build --prod --aot --build-optimizer` in an application that uses this package it throws:
`ERROR in : Unexpected value 'undefined' exported by the module 'NotificationWidgetModule in /Users/michiel/workset/digipolis/atodo/a-todo-web_app_nodejs/public/node_modules/@acpaas-ui-widgets/ngx-notification-widget/acpaas-ui-widgets-ngx-notification-widget.d.ts'`

By removing the barrel imports/files this issue is fixed.
See: 
- https://www.malcontentboffin.com/2018/10/NPM-Unexpected-value-undefined-exported-by-the-module-Module1-.html
- https://github.com/ng-packagr/ng-packagr/issues/917